### PR TITLE
fix: use standard MCP config key "url" instead of "httpUrl"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Create a `servers_config.json` file to add your MCP servers. If this file is not
 }
 ```
 
-For HTTP-based MCP servers (Streamable HTTP), use `httpUrl`:
+For HTTP-based MCP servers (Streamable HTTP), use `url`:
 
 ```json
 {
   "mcpServers": {
     "my-server": {
-      "httpUrl": "https://mcp.example.com/mcp",
+      "url": "https://mcp.example.com/mcp",
       "headers": {
         "Accept": "application/json, text/event-stream"
       }

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -104,12 +104,12 @@ class OpenAIAgent:
     def from_dict(cls, name: str, config: dict[str, Any]) -> OpenAIAgent:
         mcp_servers: list[MCPServerStreamableHttp | MCPServerStdio] = []
         for mcp_srv in config.get("mcpServers", {}).values():
-            if "httpUrl" in mcp_srv:
+            if "url" in mcp_srv:
                 mcp_servers.append(
                     MCPServerStreamableHttp(
                         client_session_timeout_seconds=MCP_SESSION_TIMEOUT_SECONDS,
                         params={
-                            "url": mcp_srv["httpUrl"],
+                            "url": mcp_srv["url"],
                             "headers": mcp_srv.get("headers", {}),
                         },
                     )


### PR DESCRIPTION
## Summary
- Replace non-standard `httpUrl` config key with `url` to align with MCP specification and Claude Desktop
- Update README documentation accordingly

## Test plan
- [x] All 59 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)