### PR TITLE
feat: add shell skills, file-based instructions, and disable tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ wheels/
 servers_config.json
 *_servers_config.json
 
+# Agent instructions (use instructions.md.example as template)
+instructions.md
+
 # Local tooling config
 .claude/
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ export SLACK_BOT_TOKEN=""
 export SLACK_APP_TOKEN=""
 export OPENAI_API_KEY=""
 export OPENAI_MODEL="gpt-5.4"
+
+# Shell skills (disabled by default)
+# export SHELL_SKILLS_ENABLED=1
 ```
 
 If you are using Azure OpenAI (v1 API) or another OpenAI-compatible endpoint:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ See also: [agentic-telegram-bot](https://github.com/John-Lin/agentic-telegram-bo
 - Channel @mention and DM support
 - Thread-aware conversations (follow-ups stay in the same thread)
 - Connects to any MCP server via `servers_config.json`
+- Local shell skills via `ShellTool` (opt-in via `SHELL_SKILLS_ENABLED`)
 - Supports OpenAI and OpenAI-compatible endpoints (including Azure OpenAI v1 API)
-- Per-conversation history with automatic truncation
+- Per-conversation history with automatic truncation (last 10 turns)
 
 ## Install Dependencies
 
@@ -57,13 +58,24 @@ Optional HTTP proxy for outbound requests:
 export HTTP_PROXY=""
 ```
 
+## Agent Instructions
+
+Create an `instructions.md` file in the project root with the agent system prompt:
+
+```markdown
+You are a helpful assistant in a Slack workspace.
+When responding, you must strictly use Slack's `mrkdwn` formatting syntax only.
+Keep responses concise and well-structured.
+```
+
+An example is provided in `instructions.md.example`. The bot will fail to start if this file is missing.
+
 ## MCP Server Configuration (Optional)
 
 Create a `servers_config.json` file to add your MCP servers. If this file is not provided, the bot starts with no MCP servers configured.
 
 ```json
 {
-  "instructions": "Your custom system prompt here.",
   "mcpServers": {
     "my-server": {
       "command": "uvx",
@@ -92,7 +104,6 @@ For local MCP servers, use `uv --directory`:
 
 ```json
 {
-  "instructions": "Your custom system prompt here.",
   "mcpServers": {
     "my-server": {
       "command": "uv",
@@ -108,6 +119,27 @@ For local MCP servers, use `uv --directory`:
 uv run bot
 ```
 
+## Shell Skills (Optional)
+
+The bot can execute local shell commands via skills defined in a `skills/` directory. Each subdirectory containing a `SKILL.md` file is registered as a skill.
+
+This feature is **disabled by default**. To enable it, set:
+
+```
+SHELL_SKILLS_ENABLED=1
+```
+
+Skills are auto-discovered at startup. The `SKILL.md` file should have YAML frontmatter with `name` and `description` fields:
+
+```markdown
+---
+name: my-skill
+description: A brief description of what this skill does
+---
+
+Detailed instructions for the agent...
+```
+
 ## Docker
 
 ```bash
@@ -119,10 +151,11 @@ docker run -d \
   -e SLACK_APP_TOKEN="" \
   -e OPENAI_API_KEY="" \
   -e OPENAI_MODEL="gpt-5.4" \
+  -v /path/to/instructions.md:/app/instructions.md \
   agentic-slackbot
 ```
 
-To use MCP servers, mount your config file:
+To use MCP servers, also mount your config:
 
 ```bash
 docker run -d \
@@ -131,6 +164,7 @@ docker run -d \
   -e SLACK_APP_TOKEN="" \
   -e OPENAI_API_KEY="" \
   -e OPENAI_MODEL="gpt-5.4" \
+  -v /path/to/instructions.md:/app/instructions.md \
   -v /path/to/servers_config.json:/app/servers_config.json \
   agentic-slackbot
 ```

--- a/bot/agent.py
+++ b/bot/agent.py
@@ -3,29 +3,46 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 from agents import Agent
 from agents import Runner
+from agents import ShellCommandRequest
+from agents import ShellTool
+from agents import ShellToolLocalEnvironment
+from agents import ShellToolLocalSkill
 from agents import TResponseInputItem
 from agents.mcp import MCPServerStdio
 from agents.mcp import MCPServerStreamableHttp
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_responses import OpenAIResponsesModel
+from agents.tracing import set_tracing_disabled
 from openai import AsyncOpenAI
 
-DEFAULT_INSTRUCTIONS = (
-    "You are agentic Slack bot, a helpful assistant.\n"
-    "When responding, you must strictly use Slack's `mrkdwn` formatting syntax only.\n"
-    "Do not generate headings (`#`), tables, or any other Markdown features not supported by Slack.\n"
-    "Ensure that all output strictly complies with Slack's `mrkdwn` specifications.\n"
-    "Your answer must be precise, of high-quality, and written by an expert using an unbiased and journalistic tone.\n"
-    "Use the language specified by user in messages as the working language when explicitly provided.\n"
-    "If you need to use Mandarin, you MUST use Traditional Chinese (台灣繁體中文)"
-)
+INSTRUCTIONS_FILE = Path("instructions.md")
 
-MAX_TURNS = 25
+MAX_TURNS = 10
 MCP_SESSION_TIMEOUT_SECONDS = 30.0
+SHELL_TIMEOUT = 30.0
+SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
+
+set_tracing_disabled(True)
+
+
+def _load_instructions() -> str:
+    """Load agent instructions from ``instructions.md`` in the working directory.
+
+    Fails fast with a clear error if the file is missing, so misconfiguration
+    is caught immediately at startup.
+    """
+    try:
+        return INSTRUCTIONS_FILE.read_text(encoding="utf-8")
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            f"Instructions file not found: {INSTRUCTIONS_FILE.resolve()}. "
+            "Create or mount instructions.md with the agent system prompt."
+        ) from e
 
 
 def _get_model() -> OpenAIResponsesModel | OpenAIChatCompletionsModel:
@@ -47,20 +64,101 @@ def _get_model() -> OpenAIResponsesModel | OpenAIChatCompletionsModel:
     return OpenAIResponsesModel(model=model_name, openai_client=client)
 
 
+def _parse_skill_description(content: str) -> str:
+    """Return the description field from a SKILL.md YAML frontmatter, or ""."""
+    if not content.startswith("---"):
+        return ""
+    end = content.find("\n---", 3)
+    if end == -1:
+        return ""
+    for line in content[3:end].splitlines():
+        if line.startswith("description:"):
+            value = line[len("description:") :].strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+            return value
+    return ""
+
+
+def _load_shell_skills() -> list[ShellToolLocalSkill]:
+    """Discover local shell skills under SKILLS_DIR.
+
+    Each immediate subdirectory of SKILLS_DIR containing a SKILL.md is mounted
+    as a ShellToolLocalSkill. The skill name is the directory name; the
+    description is read from the SKILL.md YAML frontmatter.
+    """
+    if not SKILLS_DIR.is_dir():
+        return []
+    skills: list[ShellToolLocalSkill] = []
+    for skill_dir in sorted(SKILLS_DIR.iterdir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_dir.is_dir() or not skill_md.is_file():
+            continue
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            logging.warning("Skipping unreadable skill file: %s", skill_md, exc_info=True)
+            continue
+        skills.append(
+            ShellToolLocalSkill(
+                name=skill_dir.name,
+                description=_parse_skill_description(content),
+                path=str(skill_dir),
+            )
+        )
+    return skills
+
+
+async def _shell_executor(request: ShellCommandRequest) -> str:
+    """Run each shell command from the request and return combined output.
+
+    Honours action.timeout_ms when set, otherwise falls back to SHELL_TIMEOUT.
+    stderr is merged into stdout for simplicity.
+    """
+    action = request.data.action
+    timeout = (action.timeout_ms / 1000.0) if action.timeout_ms is not None else SHELL_TIMEOUT
+
+    outputs: list[str] = []
+    for command in action.commands:
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        except OSError as e:
+            outputs.append(f"Failed to run command: {command}: {e}")
+            break
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            output = stdout.decode("utf-8", errors="replace")
+            if proc.returncode:
+                output += f"\n[exit code: {proc.returncode}]"
+            outputs.append(output)
+        except TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            outputs.append(f"Command timed out after {timeout}s: {command}")
+            break
+    return "\n".join(outputs)
+
+
 class OpenAIAgent:
-    """A wrapper for OpenAI Agent with MCP server support."""
+    """A wrapper for OpenAI Agent with MCP server and local shell skill support."""
 
     def __init__(
         self,
         name: str,
+        instructions: str,
         mcp_servers: list | None = None,
-        instructions: str = DEFAULT_INSTRUCTIONS,
+        tools: list | None = None,
     ) -> None:
         self.agent = Agent(
             name=name,
             instructions=instructions,
             model=_get_model(),
             mcp_servers=(mcp_servers if mcp_servers is not None else []),
+            tools=(tools if tools is not None else []),
         )
         self.name = name
         self._conversations: dict[str, list[TResponseInputItem]] = {}
@@ -116,8 +214,15 @@ class OpenAIAgent:
                         },
                     )
                 )
-        instructions = config.get("instructions", DEFAULT_INSTRUCTIONS)
-        return cls(name, mcp_servers, instructions=instructions)
+        tools: list[Any] = []
+        if os.getenv("SHELL_SKILLS_ENABLED"):
+            skills = _load_shell_skills()
+            if skills:
+                environment = ShellToolLocalEnvironment(type="local", skills=skills)
+                tools.append(ShellTool(executor=_shell_executor, environment=environment))
+
+        instructions = _load_instructions()
+        return cls(name, instructions=instructions, mcp_servers=mcp_servers, tools=tools)
 
     async def connect(self) -> None:
         for mcp_server in self.agent.mcp_servers:

--- a/instructions.md.example
+++ b/instructions.md.example
@@ -1,0 +1,4 @@
+You are a helpful assistant in a Slack workspace.
+When responding, you must strictly use Slack's `mrkdwn` formatting syntax only.
+Do not generate headings (`#`), tables, or any other Markdown features not supported by Slack.
+Keep responses concise and well-structured.

--- a/servers_config.example.json
+++ b/servers_config.example.json
@@ -1,5 +1,4 @@
 {
-  "instructions": "You are a helpful financial assistant. Help users look up stock data, news, and market information. Always include ticker symbols. Respond in the user's language. Keep responses concise for mobile reading. Do not offer follow-up suggestions or numbered options after answering.",
   "mcpServers": {
     "yfmcp": {
       "command": "uvx",

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,27 +1,31 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import create_autospec
 from unittest.mock import patch
 
 import pytest
+from agents import ShellTool
 from agents.models.interface import Model
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_responses import OpenAIResponsesModel
 
-from bot.agent import DEFAULT_INSTRUCTIONS
 from bot.agent import MAX_TURNS
 from bot.agent import OpenAIAgent
+from bot.agent import _parse_skill_description
+from bot.agent import _shell_executor
 
 
 @pytest.fixture(autouse=True)
-def _mock_model(monkeypatch):
-    """Prevent tests from constructing a real OpenAI client."""
+def _mock_model(monkeypatch, tmp_path_factory):
+    """Prevent tests from constructing a real OpenAI client and isolate skills."""
     monkeypatch.setattr("bot.agent._get_model", lambda: create_autospec(Model))
+    monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path_factory.mktemp("empty_skills"))
 
 
 class TestPerChannelConversations:
     def test_separate_channels_have_independent_history(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         agent.append_user_message(chat_id="C001", message="hello from C001")
         agent.append_user_message(chat_id="C002", message="hello from C002")
 
@@ -34,7 +38,7 @@ class TestPerChannelConversations:
         assert msgs_c002[0]["content"] == "hello from C002"
 
     def test_same_channel_accumulates_messages(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         agent.append_user_message(chat_id="C001", message="first")
         agent.append_user_message(chat_id="C001", message="second")
 
@@ -44,18 +48,18 @@ class TestPerChannelConversations:
         assert msgs[1]["content"] == "second"
 
     def test_unknown_channel_returns_empty(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         assert agent.get_messages(chat_id="C999") == []
 
     def test_set_messages_replaces_history(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         agent.append_user_message(chat_id="C001", message="old")
         new_msgs = [{"role": "user", "content": "replaced"}]
         agent.set_messages(chat_id="C001", messages=new_msgs)
         assert agent.get_messages(chat_id="C001") == new_msgs
 
     def test_set_messages_does_not_affect_other_channels(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         agent.append_user_message(chat_id="C001", message="channel 1")
         agent.append_user_message(chat_id="C002", message="channel 2")
         agent.set_messages(chat_id="C001", messages=[])
@@ -64,36 +68,28 @@ class TestPerChannelConversations:
 
 
 class TestInstructions:
-    def test_default_instructions_when_none_provided(self):
-        agent = OpenAIAgent(name="test")
-        assert agent.agent.instructions == DEFAULT_INSTRUCTIONS
-
     def test_custom_instructions(self):
         agent = OpenAIAgent(name="test", instructions="Be a Slack helper.")
         assert agent.agent.instructions == "Be a Slack helper."
 
-    def test_from_dict_reads_instructions(self):
-        config = {
-            "instructions": "Custom prompt here.",
-            "mcpServers": {},
-        }
-        agent = OpenAIAgent.from_dict("test", config)
-        assert agent.agent.instructions == "Custom prompt here."
+    def test_from_dict_loads_instructions_from_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "instructions.md").write_text("From file prompt.", encoding="utf-8")
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        assert agent.agent.instructions == "From file prompt."
 
-    def test_from_dict_uses_default_without_instructions(self):
-        config = {
-            "mcpServers": {},
-        }
-        agent = OpenAIAgent.from_dict("test", config)
-        assert agent.agent.instructions == DEFAULT_INSTRUCTIONS
+    def test_from_dict_fails_fast_when_instructions_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError, match="Instructions file not found"):
+            OpenAIAgent.from_dict("test", {"mcpServers": {}})
 
 
 class TestHistoryTruncation:
     def test_default_max_turns(self):
-        assert MAX_TURNS == 25
+        assert MAX_TURNS == 10
 
     def test_truncate_keeps_recent_turns(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         for i in range(30):
             agent.set_messages(
                 chat_id="C001",
@@ -109,11 +105,11 @@ class TestHistoryTruncation:
 
         user_msgs = [m for m in msgs if m["role"] == "user"]
         assert len(user_msgs) == MAX_TURNS
-        assert user_msgs[0]["content"] == "user-5"
+        assert user_msgs[0]["content"] == f"user-{30 - MAX_TURNS}"
         assert user_msgs[-1]["content"] == "user-29"
 
     def test_truncate_preserves_tool_messages_within_turn(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         history = []
         for i in range(MAX_TURNS + 2):
             history.append({"role": "user", "content": f"user-{i}"})
@@ -132,7 +128,7 @@ class TestHistoryTruncation:
         assert len(tool_msgs) == 1
 
     def test_no_truncation_when_under_limit(self):
-        agent = OpenAIAgent(name="test")
+        agent = OpenAIAgent(name="test", instructions="test-prompt")
         for i in range(3):
             agent.set_messages(
                 chat_id="C001",
@@ -150,7 +146,7 @@ class TestHistoryTruncation:
 
 
 class TestGetModel:
-    """Tests for the _get_model function's client selection logic."""
+    """Tests for the _get_model function."""
 
     @pytest.fixture(autouse=True)
     def _mock_model(self):
@@ -183,12 +179,14 @@ class TestGetModel:
         model = self._call_get_model(env)
         assert isinstance(model, OpenAIChatCompletionsModel)
 
-    def test_returns_chat_completions_when_api_type_set(self):
-        env = {"OPENAI_API_KEY": "test-key", "OPENAI_API_TYPE": "chat_completions"}
-        model = self._call_get_model(env)
-        assert isinstance(model, OpenAIChatCompletionsModel)
+
+@pytest.fixture
+def _stub_instructions(monkeypatch):
+    """Stub out instructions.md loading for from_dict tests."""
+    monkeypatch.setattr("bot.agent._load_instructions", lambda: "stub instructions")
 
 
+@pytest.mark.usefixtures("_stub_instructions")
 class TestFromDict:
     def test_creates_mcp_servers_from_config(self):
         config = {
@@ -212,3 +210,247 @@ class TestFromDict:
         config = {"mcpServers": {}}
         agent = OpenAIAgent.from_dict("test", config)
         assert agent.agent.mcp_servers == []
+
+
+@pytest.mark.usefixtures("_stub_instructions")
+class TestLoadShellSkills:
+    def _make_skill_dir(self, tmp_path):
+        """Create a valid skill directory and return its parent."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: A test skill\n---\n")
+        return tmp_path
+
+    def test_disabled_by_default(self, tmp_path, monkeypatch):
+        """Skills exist but SHELL_SKILLS_ENABLED is not set — no ShellTool."""
+        monkeypatch.delenv("SHELL_SKILLS_ENABLED", raising=False)
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", self._make_skill_dir(tmp_path))
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tools = [t for t in agent.agent.tools if isinstance(t, ShellTool)]
+        assert len(shell_tools) == 0
+
+    def test_enabled_with_env_var(self, tmp_path, monkeypatch):
+        """SHELL_SKILLS_ENABLED=1 and skills exist — ShellTool is added."""
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", self._make_skill_dir(tmp_path))
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tools = [t for t in agent.agent.tools if isinstance(t, ShellTool)]
+        assert len(shell_tools) == 1
+
+    def test_no_shell_tool_when_skills_dir_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path / "nonexistent")
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tools = [t for t in agent.agent.tools if isinstance(t, ShellTool)]
+        assert len(shell_tools) == 0
+
+    def test_shell_tool_added_when_skill_found(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: A test skill\n---\n")
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path)
+
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tool = next(t for t in agent.agent.tools if isinstance(t, ShellTool))
+        skill = shell_tool.environment["skills"][0]
+        assert skill["name"] == "my-skill"
+        assert skill["description"] == "A test skill"
+        assert skill["path"] == str(skill_dir)
+
+    def test_multiple_skills_all_mounted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        for name in ["skill-a", "skill-b"]:
+            d = tmp_path / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: desc {name}\n---\n")
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path)
+
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tool = next(t for t in agent.agent.tools if isinstance(t, ShellTool))
+        assert len(shell_tool.environment["skills"]) == 2
+
+    def test_directory_without_skill_md_is_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        (tmp_path / "not-a-skill").mkdir()
+        good = tmp_path / "real-skill"
+        good.mkdir()
+        (good / "SKILL.md").write_text("---\nname: real-skill\ndescription: d\n---\n")
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path)
+
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tool = next(t for t in agent.agent.tools if isinstance(t, ShellTool))
+        skills = shell_tool.environment["skills"]
+        assert len(skills) == 1
+        assert skills[0]["name"] == "real-skill"
+
+    def test_mcp_servers_and_shell_skills_coexist(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        skill_dir = tmp_path / "s"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path)
+
+        config = {"mcpServers": {"my-mcp": {"command": "uvx", "args": ["something"]}}}
+        agent = OpenAIAgent.from_dict("test", config)
+        assert len(agent.agent.mcp_servers) == 1
+        shell_tools = [t for t in agent.agent.tools if isinstance(t, ShellTool)]
+        assert len(shell_tools) == 1
+
+    def test_unreadable_utf8_skill_file_is_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        bad = tmp_path / "bad-skill"
+        bad.mkdir()
+        (bad / "SKILL.md").write_bytes(b"\xff\xfe\x00\x00")
+
+        good = tmp_path / "good-skill"
+        good.mkdir()
+        (good / "SKILL.md").write_text("---\nname: good-skill\ndescription: good\n---\n")
+
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path)
+
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tool = next(t for t in agent.agent.tools if isinstance(t, ShellTool))
+        skills = shell_tool.environment["skills"]
+        assert len(skills) == 1
+        assert skills[0]["name"] == "good-skill"
+
+    def test_oserror_reading_skill_file_is_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SHELL_SKILLS_ENABLED", "1")
+        bad = tmp_path / "bad-skill"
+        bad.mkdir()
+        bad_file = bad / "SKILL.md"
+        bad_file.write_text("---\nname: bad\ndescription: bad\n---\n")
+
+        good = tmp_path / "good-skill"
+        good.mkdir()
+        (good / "SKILL.md").write_text("---\nname: good-skill\ndescription: good\n---\n")
+
+        original_read_text = Path.read_text
+
+        def _read_text(self: Path, *args, **kwargs):
+            if self == bad_file:
+                raise OSError("permission denied")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr("bot.agent.SKILLS_DIR", tmp_path)
+        monkeypatch.setattr(Path, "read_text", _read_text)
+
+        agent = OpenAIAgent.from_dict("test", {"mcpServers": {}})
+        shell_tool = next(t for t in agent.agent.tools if isinstance(t, ShellTool))
+        skills = shell_tool.environment["skills"]
+        assert len(skills) == 1
+        assert skills[0]["name"] == "good-skill"
+
+
+class TestParseSkillDescription:
+    def test_unquoted_description(self):
+        content = "---\nname: my-skill\ndescription: A test skill\n---\nBody text."
+        assert _parse_skill_description(content) == "A test skill"
+
+    def test_double_quoted_description(self):
+        content = '---\nname: my-skill\ndescription: "A quoted skill"\n---\n'
+        assert _parse_skill_description(content) == "A quoted skill"
+
+    def test_single_quoted_description(self):
+        content = "---\nname: my-skill\ndescription: 'Single quoted'\n---\n"
+        assert _parse_skill_description(content) == "Single quoted"
+
+    def test_no_frontmatter(self):
+        content = "Just a plain markdown file."
+        assert _parse_skill_description(content) == ""
+
+    def test_no_description_field(self):
+        content = "---\nname: my-skill\n---\nBody."
+        assert _parse_skill_description(content) == ""
+
+    def test_unclosed_frontmatter(self):
+        content = "---\nname: my-skill\ndescription: never closed"
+        assert _parse_skill_description(content) == ""
+
+    def test_empty_description(self):
+        content = "---\nname: my-skill\ndescription:\n---\n"
+        assert _parse_skill_description(content) == ""
+
+    def test_description_with_colon_in_value(self):
+        content = "---\ndescription: Run this: do stuff\n---\n"
+        assert _parse_skill_description(content) == "Run this: do stuff"
+
+
+def _make_shell_request(commands: list[str], timeout_ms: int | None = None):
+    """Build a minimal object matching the ShellCommandRequest interface."""
+    from types import SimpleNamespace
+
+    action = SimpleNamespace(commands=commands, timeout_ms=timeout_ms)
+    data = SimpleNamespace(action=action)
+    return SimpleNamespace(data=data)
+
+
+class TestShellExecutor:
+    @pytest.mark.anyio
+    async def test_single_command_returns_stdout(self):
+        request = _make_shell_request(["echo hello"])
+        result = await _shell_executor(request)
+        assert result.strip() == "hello"
+
+    @pytest.mark.anyio
+    async def test_multiple_commands_combined(self):
+        request = _make_shell_request(["echo first", "echo second"])
+        result = await _shell_executor(request)
+        assert "first" in result
+        assert "second" in result
+        assert result.index("first") < result.index("second")
+
+    @pytest.mark.anyio
+    async def test_stderr_merged_into_stdout(self):
+        request = _make_shell_request(["echo err >&2"])
+        result = await _shell_executor(request)
+        assert result.strip() == "err"
+
+    @pytest.mark.anyio
+    async def test_command_timeout_kills_process(self):
+        request = _make_shell_request(["sleep 30"], timeout_ms=100)
+        result = await _shell_executor(request)
+        assert "timed out" in result.lower()
+
+    @pytest.mark.anyio
+    async def test_nonzero_exit_code_appends_exit_code(self):
+        request = _make_shell_request(["echo failing && exit 1"])
+        result = await _shell_executor(request)
+        assert "failing" in result
+        assert "[exit code: 1]" in result
+
+    @pytest.mark.anyio
+    async def test_zero_exit_code_no_suffix(self):
+        request = _make_shell_request(["echo ok"])
+        result = await _shell_executor(request)
+        assert "exit code" not in result
+
+    @pytest.mark.anyio
+    async def test_timeout_ms_none_uses_default(self):
+        """When timeout_ms is None, SHELL_TIMEOUT is used (command completes fine)."""
+        request = _make_shell_request(["echo ok"], timeout_ms=None)
+        result = await _shell_executor(request)
+        assert result.strip() == "ok"
+
+    @pytest.mark.anyio
+    async def test_timeout_stops_remaining_commands(self):
+        """After a timeout, subsequent commands are not executed."""
+        request = _make_shell_request(["sleep 30", "echo should-not-run"], timeout_ms=100)
+        result = await _shell_executor(request)
+        assert "timed out" in result.lower()
+        assert "should-not-run" not in result
+
+    @pytest.mark.anyio
+    async def test_subprocess_oserror_returns_error_message(self, monkeypatch):
+        """When create_subprocess_shell raises OSError, return error text instead of crashing."""
+        import asyncio as _asyncio
+
+        async def _failing_shell(*args, **kwargs):
+            raise OSError("fork failed")
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_shell", _failing_shell)
+
+        request = _make_shell_request(["echo hello"])
+        result = await _shell_executor(request)
+        assert "fork failed" in result


### PR DESCRIPTION
## Summary

- Load agent instructions from `instructions.md` file instead of hardcoded `DEFAULT_INSTRUCTIONS`, with fail-fast behavior when file is missing
- Add `ShellTool` support with auto-discovered skills from `skills/` directory, gated behind `SHELL_SKILLS_ENABLED` environment variable
- Disable OpenAI tracing via `set_tracing_disabled(True)`
- Reduce `MAX_TURNS` from 25 to 10 for consistency across all three bots (Telegram, Discord, Slack)

## Changes

### `bot/agent.py`
- Remove `DEFAULT_INSTRUCTIONS` constant
- Add `_load_instructions()` — reads `instructions.md` from working directory
- Add `_parse_skill_description()` — extracts description from SKILL.md YAML frontmatter
- Add `_load_shell_skills()` — auto-discovers skills under `skills/` directory
- Add `_shell_executor()` — async shell command runner with timeout support
- Update `OpenAIAgent.__init__` to accept `tools` parameter, make `instructions` required (no default)
- Update `OpenAIAgent.from_dict` to use file-based instructions and conditionally load shell skills

### Tests (`tests/test_agent.py`)
- Add `TestLoadShellSkills` (9 tests) — env var gating, skill discovery, error handling
- Add `TestParseSkillDescription` (8 tests) — frontmatter parsing edge cases
- Add `TestShellExecutor` (9 tests) — command execution, timeouts, error handling
- Update `TestInstructions` for file-based loading
- Update `TestHistoryTruncation` to assert `MAX_TURNS == 10`
- Remove obsolete Azure/proxy client tests
- Total: 81 tests (up from 57)

### Documentation
- Add `instructions.md.example` template
- Remove `instructions` field from `servers_config.example.json`
- Add `.gitignore` entry for `instructions.md`
- Update README: add Agent Instructions, Shell Skills sections; update Docker examples to mount `instructions.md`