### PR TITLE
Fix DM session key to use channel ID instead of message ts

### DIFF
--- a/bot/slack.py
+++ b/bot/slack.py
@@ -101,10 +101,13 @@ class SlackMCPBot:
             display_name = await self._get_display_name(user_id)
             user_text = f"[{display_name}] {user_text}"
 
+        # DMs use the channel ID as session key so all messages share one conversation.
+        # Threads use thread_ts so each thread has its own isolated conversation.
         thread_ts = event.get("thread_ts", event.get("ts"))
+        session_key = event["channel"] if event.get("channel_type") == "im" else thread_ts
 
         try:
-            asst_text = await self.agent.run(thread_ts, user_text)
+            asst_text = await self.agent.run(session_key, user_text)
             mrkdwn_text = markdown_to_slack_mrkdwn(str(asst_text))
             try:
                 await say(text=mrkdwn_text, channel=channel, thread_ts=thread_ts)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -110,7 +110,8 @@ class TestHandleMention:
 
 class TestHandleMessage:
     @pytest.mark.anyio
-    async def test_dm_calls_agent(self, bot):
+    async def test_dm_uses_channel_as_session_key(self, bot):
+        """DM messages must use channel ID as session key so consecutive messages share history."""
         message = {
             "channel": "D001",
             "channel_type": "im",
@@ -123,7 +124,23 @@ class TestHandleMessage:
 
         await bot.handle_message(message, say, ack)
 
-        bot.agent.run.assert_called_once_with("1234567890.123456", "[Alice] hello")
+        bot.agent.run.assert_called_once_with("D001", "[Alice] hello")
+
+    @pytest.mark.anyio
+    async def test_dm_consecutive_messages_share_session(self, bot):
+        """Two consecutive DM messages must use the same session key."""
+        say = AsyncMock()
+        ack = AsyncMock()
+
+        for ts in ("1111.111", "2222.222"):
+            await bot.handle_message(
+                {"channel": "D001", "channel_type": "im", "user": "U123", "text": "msg", "ts": ts},
+                say,
+                ack,
+            )
+
+        keys = [call.args[0] for call in bot.agent.run.call_args_list]
+        assert keys[0] == keys[1] == "D001"
 
     @pytest.mark.anyio
     async def test_non_dm_is_ignored(self, bot):


### PR DESCRIPTION
Each DM message had a unique ts, so consecutive messages in a DM created separate sessions — the bot had no memory between turns.

DMs now use channel ID as the session key so the full DM conversation shares one history. Thread sessions are unchanged (still keyed by thread_ts).